### PR TITLE
Fix bidirectional streaming for server-initiated responses

### DIFF
--- a/ag-grpc/server.lisp
+++ b/ag-grpc/server.lisp
@@ -340,10 +340,20 @@ If GRACEFUL is true, wait for active connections to finish."
       ;; Store context for DATA frame handling
       (setf (stream-call-context h2-stream) ctx)
       (setf (stream-handler h2-stream) handler)
-      ;; If END_STREAM is set, this is a unary call with no body
-      ;; (unusual but valid for requests with no data)
-      (when (plusp (logand (ag-http2:frame-flags frame) ag-http2:+flag-end-stream+))
-        (server-dispatch-handler server conn ctx handler nil)))))
+      ;; For streaming RPCs, dispatch handler immediately so it can read DATA
+      ;; frames via stream-recv. For unary RPCs, wait for END_STREAM.
+      (let ((is-streaming (or (handler-client-streaming-p handler)
+                              (handler-server-streaming-p handler))))
+        (if is-streaming
+            ;; Start streaming handler immediately in main thread
+            ;; (handler's stream-recv will read DATA frames)
+            (handler-case
+                (server-dispatch-handler server conn ctx handler nil)
+              (error (e)
+                (format *error-output* "~&gRPC handler error: ~A~%" e)))
+            ;; Unary: wait for END_STREAM
+            (when (plusp (logand (ag-http2:frame-flags frame) ag-http2:+flag-end-stream+))
+              (server-dispatch-handler server conn ctx handler nil)))))))
 
 (defun server-handle-data (server conn frame)
   "Handle incoming DATA frame (request body)"

--- a/ag-http2/connection.lisp
+++ b/ag-http2/connection.lisp
@@ -188,7 +188,10 @@ Reads and validates client preface, exchanges SETTINGS frames."
     (write-frame frame (connection-stream conn))
     (force-output (connection-stream conn))
     (let ((stream (multiplexer-get-stream (connection-multiplexer conn) stream-id)))
-      (stream-transition stream :send-headers)
+      ;; Only transition if stream is idle (server responses on client-initiated
+      ;; streams are already open from receiving client headers)
+      (when (eq (stream-state stream) :idle)
+        (stream-transition stream :send-headers))
       (when end-stream
         (stream-transition stream :send-end-stream)))))
 
@@ -290,16 +293,14 @@ ERROR-CODE is an HTTP/2 error code (e.g., +error-cancel+ for client cancellation
        (if end-headers-p
            ;; Complete header block - decode immediately
            (let* ((decoder (connection-hpack-decoder conn))
-                  (header-block (extract-header-block frame)))
-             (format *error-output* "~&  header-block-len=~A first-10: ~{~2,'0X ~}~%"
-                     (length header-block) (coerce (subseq header-block 0 (min 10 (length header-block))) 'list))
-             (let ((headers (hpack-decode decoder header-block)))
-               (stream-transition stream :recv-headers)
-               (if (stream-headers stream)
-                   (setf (stream-trailers stream) headers)
-                   (setf (stream-headers stream) headers))
-               (when end-stream-p
-                 (stream-transition stream :recv-end-stream))))
+                  (header-block (extract-header-block frame))
+                  (headers (hpack-decode decoder header-block)))
+             (stream-transition stream :recv-headers)
+             (if (stream-headers stream)
+                 (setf (stream-trailers stream) headers)
+                 (setf (stream-headers stream) headers))
+             (when end-stream-p
+               (stream-transition stream :recv-end-stream)))
            ;; Incomplete - buffer and wait for CONTINUATION
            (progn
              (setf (connection-pending-header-block conn)


### PR DESCRIPTION
## Summary

Two fixes for bidirectional streaming RPCs:

- **Stream state transition error**: When a server sends response headers on a client-initiated stream, the stream is already in `:OPEN` state (from receiving the client's HEADERS). Calling `stream-transition` with `:send-headers` on an `:OPEN` stream caused an invalid state transition error (`:send-headers` is not a valid event in `:OPEN` state). Fixed by only calling `stream-transition` if the stream is in `:IDLE` state.

- **Streaming handler dispatch timing**: For streaming RPCs, the handler needs to be dispatched immediately when HEADERS are received, not when END_STREAM is set. The handler's `stream-recv` calls need to read incoming DATA frames, which requires the handler to be running. Fixed by dispatching streaming handlers immediately in the main thread.

Also removed debug output from header block processing.

## Test plan

- [x] Test with bidirectional streaming gRPC call
- [x] Verify client connects and handler is invoked
- [x] Verify messages can be sent/received in both directions

🤖 Generated with [Claude Code](https://claude.com/claude-code)