### PR TITLE
Add --class-prefix option to ag-protoc

### DIFF
--- a/ag-proto-cli/main.lisp
+++ b/ag-proto-cli/main.lisp
@@ -71,6 +71,14 @@
    :key :include-paths
    :description "Add directory to proto import search path (can be repeated)"))
 
+(defun make-class-prefix-option ()
+  "Create --class-prefix option for adding prefix to generated classes."
+  (clingon:make-option
+   :string
+   :long-name "class-prefix"
+   :key :class-prefix
+   :description "Prefix to add to all generated class and accessor names (e.g., PROTO-)"))
+
 ;;; -------------------------------------------------------------------------
 ;;; CLI Handler
 ;;; -------------------------------------------------------------------------
@@ -93,7 +101,7 @@
         (merge-pathnames output-name (ensure-directory-pathname output-dir))
         output-name)))
 
-(defun compile-proto-to-lisp (input-file &key output-file package load verbose print include-paths)
+(defun compile-proto-to-lisp (input-file &key output-file package load verbose print include-paths class-prefix)
   "Compile a single .proto file to Lisp."
   (when verbose
     (format *error-output* "; Compiling ~A~%" input-file))
@@ -105,7 +113,8 @@
          ;; Collect enum types from all parsed files (including imports)
          (all-enum-types (ag-proto:get-all-enum-types))
          (forms (ag-proto:generate-lisp-code file-desc :package pkg
-                                              :additional-enum-types all-enum-types)))
+                                              :additional-enum-types all-enum-types
+                                              :class-prefix class-prefix)))
     ;; Write to output file if specified
     (when output-file
       (when verbose
@@ -147,6 +156,7 @@
         (print (clingon:getopt cmd :print))
         (verbose (clingon:getopt cmd :verbose))
         (include-paths (clingon:getopt cmd :include-paths))
+        (class-prefix (clingon:getopt cmd :class-prefix))
         (args (clingon:command-arguments cmd)))
     ;; Validate arguments
     (unless args
@@ -176,7 +186,8 @@
                                    :load load
                                    :verbose verbose
                                    :print print
-                                   :include-paths include-paths)))
+                                   :include-paths include-paths
+                                   :class-prefix class-prefix)))
       (error (e)
         (format *error-output* "Error: ~A~%" e)
         (uiop:quit 1)))))
@@ -213,7 +224,8 @@ Examples:
                   (make-load-option)
                   (make-print-option)
                   (make-verbose-option)
-                  (make-include-path-option))
+                  (make-include-path-option)
+                  (make-class-prefix-option))
    :handler #'handle-cli))
 
 ;;; -------------------------------------------------------------------------

--- a/ag-proto/codegen.lisp
+++ b/ag-proto/codegen.lisp
@@ -18,6 +18,10 @@
 Used to determine if a field type should be serialized as varint (enum) or
 length-delimited (message).")
 
+(defvar *class-prefix* nil
+  "Optional prefix to add to generated class and accessor names.
+For example, setting this to \"PROTO-\" will generate class names like PROTO-FOO-BAR.")
+
 (defun enum-type-p (type-name)
   "Return T if TYPE-NAME refers to a known enum type."
   (and *known-enum-types*
@@ -57,6 +61,12 @@ length-delimited (message).")
                 (write-char (char-upcase char) s))))
     (when suffix
       (write-string suffix s))))
+
+(defun prefixed-lisp-name (name &optional suffix)
+  "Convert a proto name to a prefixed Lisp symbol name using *class-prefix*."
+  (if *class-prefix*
+      (concatenate 'string *class-prefix* (lisp-name name suffix))
+      (lisp-name name suffix)))
 
 ;;; Type mapping
 
@@ -103,20 +113,28 @@ length-delimited (message).")
   "CL symbols that should not be used as accessor names (to avoid package lock violations)")
 
 (defun safe-accessor-name (name package)
-  "Generate a safe accessor name, prefixing if it conflicts with CL symbols"
-  (let ((upname (string-upcase (substitute #\- #\_ name))))
-    (if (member upname *cl-reserved-names* :test #'string=)
-        (intern (concatenate 'string "PROTO-" upname) package)
-        (intern upname package))))
+  "Generate a safe accessor name, prefixing if it conflicts with CL symbols or if *CLASS-PREFIX* is set"
+  (let* ((upname (string-upcase (substitute #\- #\_ name)))
+         (prefix (or *class-prefix*
+                     (when (member upname *cl-reserved-names* :test #'string=)
+                       "PROTO-")))
+         (final-name (if prefix
+                         (concatenate 'string prefix upname)
+                         upname)))
+    (intern final-name package)))
 
 (defun safe-class-name (name package)
-  "Generate a safe class name, prefixing if it conflicts with CL symbols.
+  "Generate a safe class name, prefixing if it conflicts with CL symbols or if *CLASS-PREFIX* is set.
 NAME should already be in LISP-NAME format (e.g., FOO-BAR).
 If PACKAGE is nil, interns in the current package (*PACKAGE*)."
-  (let ((target-package (or package *package*)))
-    (if (member name *cl-reserved-names* :test #'string=)
-        (intern (concatenate 'string "PROTO-" name) target-package)
-        (intern name target-package))))
+  (let* ((target-package (or package *package*))
+         (prefix (or *class-prefix*
+                     (when (member name *cl-reserved-names* :test #'string=)
+                       "PROTO-")))
+         (final-name (if prefix
+                         (concatenate 'string prefix name)
+                         name)))
+    (intern final-name target-package)))
 
 (defun field-name-to-slot-name (name)
   "Convert a field name to a slot name symbol, prefixing with PROTO- if it conflicts with CL"
@@ -577,11 +595,12 @@ Includes top-level enums and nested enums from messages."
         (collect-from-message msg nil)))
     enum-table))
 
-(defun generate-lisp-code (file-desc &key (package *package*) (generate-stubs t) additional-enum-types)
+(defun generate-lisp-code (file-desc &key (package *package*) (generate-stubs t) additional-enum-types class-prefix)
   "Generate Lisp code for all messages in a proto file descriptor.
 Returns a list of forms to be compiled.
 If GENERATE-STUBS is true (default), also generates client stubs for services.
-ADDITIONAL-ENUM-TYPES is a hash table of extra enum type names to include (from imports)."
+ADDITIONAL-ENUM-TYPES is a hash table of extra enum type names to include (from imports).
+CLASS-PREFIX is an optional string to prefix all generated class and accessor names (e.g., \"PROTO-\")."
   ;; Build enum types table for this file, merging with additional types
   (let* ((local-enums (collect-enum-names file-desc))
          (*known-enum-types* (if additional-enum-types
@@ -591,6 +610,7 @@ ADDITIONAL-ENUM-TYPES is a hash table of extra enum type names to include (from 
                                             additional-enum-types)
                                    local-enums)
                                  local-enums))
+         (*class-prefix* class-prefix)
          (messages (proto-file-messages file-desc))
          (enums (proto-file-enums file-desc))
          (services (proto-file-services file-desc))


### PR DESCRIPTION
## Summary

Adds a `--class-prefix` option to ag-protoc that allows prefixing all generated class and accessor names. This helps avoid naming conflicts when integrating generated proto code into existing projects.

## Changes

- **ag-proto/codegen.lisp**: 
  - Add `*class-prefix*` special variable
  - Update `safe-class-name` and `safe-accessor-name` to honor the prefix
  - Add `class-prefix` parameter to `generate-lisp-code`

- **ag-proto-cli/main.lisp**:
  - Add `make-class-prefix-option` to create the CLI option
  - Wire the option through `compile-proto-to-lisp` and `handle-cli`

## Example Usage

```bash
ag-protoc --class-prefix PROTO- -o output.lisp input.proto
```

This generates:
- Class names like `PROTO-FOO-BAR` instead of `FOO-BAR`  
- Accessors like `PROTO-NAME` instead of `NAME`

## Backward Compatibility

The feature is fully backward compatible:
- When no prefix is specified, behavior is unchanged
- The existing automatic `PROTO-` prefix for CL reserved names still applies
- The prefix is additive - it's applied before the reserved-name check

## Use Case

I'm using this in [cloodoo](https://github.com/atgreen/cloodoo) where the proto definitions have messages like `TodoData` and `TodoChange` that would conflict with existing model classes `todo` and `change`. With `--class-prefix PROTO-`, the generated code produces `proto-todo-data` and `proto-todo-change`, avoiding the conflict.