### PR TITLE
Fix a type error in a test.

### DIFF
--- a/tests/codegen-tests.lisp
+++ b/tests/codegen-tests.lisp
@@ -75,7 +75,8 @@ message AllScalars {
                                   :sf64 -123456789012
                                   :b t
                                   :s "test string"
-                                  :by #(1 2 3 4 5)))
+                                  :by (make-array 5 :element-type '(unsigned-byte 8)
+                                                    :initial-contents #(1 2 3 4 5))))
          (bytes (ag-proto:serialize-to-bytes original))
          (restored (ag-proto:deserialize-from-bytes 'all-scalars bytes)))
     ;; Check floats with tolerance


### PR DESCRIPTION
The protobuf field cannot be initialized with #(1 2 3 4 5) because it must be a specialized vector of octets, not a simple vector.
