### PR TITLE
Fix: Add missing stream-cancel-context for server streams

### DIFF
--- a/ag-grpc/server.lisp
+++ b/ag-grpc/server.lisp
@@ -982,3 +982,12 @@ Returns: (values message found-p) or (values nil nil) if closed."
   (bt:with-lock-held ((ag-http2:connection-stream-state-lock conn))
     (remhash stream (ag-http2:connection-stream-contexts conn))
     (remhash stream (ag-http2:connection-stream-handlers conn))))
+
+;;;; ========================================================================
+;;;; Stream Cancel Context Accessor
+;;;; ========================================================================
+
+(defmethod stream-cancel-context ((stream grpc-server-call-stream))
+  "Return the cancel context for a server stream.
+Server streams delegate to their call context."
+  (context-cancel-context (server-stream-context stream)))


### PR DESCRIPTION
## Problem

The `:around` method on `stream-send` (call.lisp:620) calls `stream-cancel-context` on all stream types, but `grpc-server-call-stream` doesn't have this accessor defined. This causes all server-side streaming RPCs to fail with:

```
There is no applicable method for the generic function stream-cancel-context
when called with arguments (#<GRPC-SERVER-CALL-STREAM>)
```

## Root Cause

The `:around` method wraps all `stream-send` calls to bind the cancel context:

```lisp
(defmethod stream-send :around ((stream t) message)
  "Wrap all stream-send methods with context binding."
  (let ((ctx (stream-cancel-context stream)))  ; <-- Fails for server streams
    (cl-cancel:with-cancel-context (ctx ctx)
      (call-next-method))))
```

This works for client streams but not server streams because:
- **Client streams** (`grpc-client-call-stream`) have `stream-cancel-context` accessor defined
- **Server streams** (`grpc-server-call-stream`) do NOT have this accessor

## Solution

Add the missing `stream-cancel-context` method for server streams:

```lisp
(defmethod stream-cancel-context ((stream grpc-server-call-stream))
  "Return the cancel context for a server stream.
Server streams delegate to their call context."
  (context-cancel-context (server-stream-context stream)))
```

Server streams store their cancel context in the `grpc-call-context` object (accessed via `server-stream-context`), which has the `context-cancel-context` accessor.

## Testing

✅ Tested with bidirectional streaming RPC  
✅ Server successfully sends ACK and messages to clients  
✅ No errors during stream operations  

## Impact

This fix enables server-side streaming RPCs (unary, server-streaming, client-streaming, and bidi-streaming) to work correctly with the cancel context integration added in the recent cl-cancel updates.