### PR TITLE
http2/grpc: bound inbound resources; harden frame size and percent-de…

### DIFF
--- a/ag-grpc-all.asd
+++ b/ag-grpc-all.asd
@@ -20,4 +20,5 @@
                (:file "codegen-tests")
                (:file "hpack-tests")
                (:file "http2-tests")
-               (:file "grpc-tests")))
+               (:file "grpc-tests")
+               (:file "security-tests")))

--- a/ag-grpc/metadata.lisp
+++ b/ag-grpc/metadata.lisp
@@ -427,7 +427,13 @@ Properly handles UTF-8 encoded bytes."
           for char = (char string i)
           do (cond
                ((and (char= char #\%)
-                     (<= (+ i 2) len))
+                     ;; grpc-message is peer-supplied: only treat "%XX" as an
+                     ;; escape when two hex digits actually follow, otherwise
+                     ;; emit '%' literally. Avoids parse-integer signalling on a
+                     ;; truncated ("...%2") or non-hex ("...%ZZ") escape.
+                     (<= (+ i 3) len)
+                     (digit-char-p (char string (+ i 1)) 16)
+                     (digit-char-p (char string (+ i 2)) 16))
                 ;; Percent-encoded byte
                 (vector-push-extend (parse-integer string
                                                    :start (1+ i)
@@ -436,7 +442,7 @@ Properly handles UTF-8 encoded bytes."
                                     bytes)
                 (incf i 3))
                (t
-                ;; Plain ASCII character
+                ;; Plain ASCII character (including a bare/invalid '%')
                 (vector-push-extend (char-code char) bytes)
                 (incf i))))
     ;; Convert UTF-8 bytes to string

--- a/ag-http2/connection.lisp
+++ b/ag-http2/connection.lisp
@@ -28,6 +28,19 @@
   (:documentation "Error during frame parsing (incomplete or malformed frame)"))
 
 ;;;; ========================================================================
+;;;; Receive limits
+;;;; ========================================================================
+
+(defparameter *max-receive-buffer-size* (* 4 1024 1024)
+  "Maximum number of buffered-but-unconsumed request bytes per stream. A peer
+that streams DATA without END_STREAM (or declares a huge gRPC length and
+trickles the body) would otherwise grow the per-stream buffer without bound and
+exhaust memory, because the receiver replenishes its flow-control window as data
+is accepted. Once the buffered data for a stream exceeds this cap the connection
+is failed with ENHANCE_YOUR_CALM. Bind to NIL to disable. Default: 4 MB (the
+gRPC default max receive message size).")
+
+;;;; ========================================================================
 ;;;; HTTP/2 Connection
 ;;;; ========================================================================
 
@@ -351,7 +364,10 @@ ERROR-CODE is an HTTP/2 error code (e.g., +error-cancel+ for client cancellation
 
 (defun connection-read-frame (conn)
   "Read and process a frame from the connection"
-  (let ((frame (read-frame (connection-stream conn))))
+  (let ((frame (read-frame (connection-stream conn)
+                           (or (rest (assoc +settings-max-frame-size+
+                                            (connection-local-settings conn)))
+                               +default-max-frame-size+))))
     (when frame
       (process-frame conn frame))
     frame))
@@ -462,6 +478,16 @@ ERROR-CODE is an HTTP/2 error code (e.g., +error-cancel+ for client cancellation
             (stream (multiplexer-get-stream (connection-multiplexer conn) stream-id))
             (data-length (length (frame-payload frame))))
        (stream-append-data stream (frame-payload frame))
+       ;; Bound the buffered-but-unconsumed request data. Without this a peer
+       ;; can stream DATA forever (no END_STREAM) and exhaust memory, since the
+       ;; window is replenished below as data is accepted.
+       (when (and *max-receive-buffer-size*
+                  (> (length (stream-data-buffer stream)) *max-receive-buffer-size*))
+         (error 'http2-connection-error
+                :message (format nil "Stream ~D buffered ~D bytes exceeds max-receive-buffer-size ~D"
+                                 stream-id (length (stream-data-buffer stream))
+                                 *max-receive-buffer-size*)
+                :error-code +error-enhance-your-calm+))
        ;; Update local flow control windows and send WINDOW_UPDATE
        (when (plusp data-length)
          ;; Consume from local windows

--- a/ag-http2/constants.lisp
+++ b/ag-http2/constants.lisp
@@ -33,6 +33,12 @@
 (defconstant +settings-max-frame-size+ #x5)
 (defconstant +settings-max-header-list-size+ #x6)
 
+;;; RFC 7540 4.2: the initial/minimum SETTINGS_MAX_FRAME_SIZE. A peer may not
+;;; send a frame larger than the value the receiver advertised; the default
+;;; (and floor) is 2^14. read-frame uses this to reject oversize frames before
+;;; allocating their payload (FRAME_SIZE_ERROR).
+(defconstant +default-max-frame-size+ 16384)
+
 ;;; Default settings values
 (defparameter *default-settings*
   `((,+settings-header-table-size+ . 4096)

--- a/ag-http2/frames.lisp
+++ b/ag-http2/frames.lisp
@@ -127,11 +127,16 @@ Handles partial reads by retrying until complete or EOF."
                  (setf total read)))
     total))
 
-(defun read-frame (stream)
+(defun read-frame (stream &optional (max-frame-size +default-max-frame-size+))
   "Read an HTTP/2 frame from a binary stream.
 Signals END-OF-FILE on a clean peer close (zero bytes available),
 HTTP2-FRAME-ERROR on a truncated header. Returning NIL here would
-strand callers in their read loops, busy-spinning on a dead socket."
+strand callers in their read loops, busy-spinning on a dead socket.
+
+MAX-FRAME-SIZE is the receiver's advertised SETTINGS_MAX_FRAME_SIZE. RFC 7540
+4.2 requires rejecting a frame whose declared length exceeds it; the check
+happens BEFORE the payload is allocated so a 9-byte header cannot force a
+multi-megabyte (up to 2^24-1) allocation."
   (let* ((header (make-array 9 :element-type '(unsigned-byte 8)))
          (header-bytes (read-full-sequence header stream)))
     (cond
@@ -147,12 +152,18 @@ strand callers in their read loops, busy-spinning on a dead socket."
            (stream-id (logior (ash (logand (aref header 5) #x7f) 24)
                               (ash (aref header 6) 16)
                               (ash (aref header 7) 8)
-                              (aref header 8)))
-           (payload (make-array length :element-type '(unsigned-byte 8))))
-      (when (and (plusp length)
-                 (/= length (read-full-sequence payload stream)))
-        (error 'http2-frame-error :message "Incomplete frame payload"))
-      (make-frame-from-raw type flags stream-id payload))))
+                              (aref header 8))))
+      ;; RFC 7540 4.2: reject (FRAME_SIZE_ERROR) before allocating the payload.
+      (when (> length max-frame-size)
+        (error 'http2-frame-error
+               :message (format nil "Frame length ~D exceeds SETTINGS_MAX_FRAME_SIZE ~D"
+                                length max-frame-size)
+               :error-code +error-frame-size-error+))
+      (let ((payload (make-array length :element-type '(unsigned-byte 8))))
+        (when (and (plusp length)
+                   (/= length (read-full-sequence payload stream)))
+          (error 'http2-frame-error :message "Incomplete frame payload"))
+        (make-frame-from-raw type flags stream-id payload)))))
 
 (defun make-frame-from-raw (type flags stream-id payload)
   "Create an appropriate frame object from raw frame data"

--- a/tests/package.lisp
+++ b/tests/package.lisp
@@ -12,7 +12,8 @@
    #:codegen-tests
    #:hpack-tests
    #:http2-tests
-   #:grpc-tests))
+   #:grpc-tests
+   #:security-tests))
 
 (in-package #:ag-grpc-tests)
 
@@ -41,6 +42,11 @@
 
 (def-suite grpc-tests
   :description "gRPC protocol tests"
+  :in ag-grpc-all-tests)
+
+(def-suite security-tests
+  :description "Security regression reproducers (triage candidates; expected
+RED until the corresponding fixes land)"
   :in ag-grpc-all-tests)
 
 (defun run-tests ()

--- a/tests/security-tests.lisp
+++ b/tests/security-tests.lisp
@@ -1,0 +1,120 @@
+;;;; security-tests.lisp - Security regression reproducers
+;;;;
+;;;; These are TRIAGE-CANDIDATE reproducers from an in-session security scan.
+;;;; Each asserts the *correct/secure* behavior, so it is expected to FAIL on
+;;;; the current (unfixed) tree and turn green once the corresponding fix lands.
+;;;; They are intentionally wired into AG-GRPC-ALL-TESTS as failing tripwires.
+;;;;
+;;;;   MEDIUM-1  data-frame-buffering-is-bounded
+;;;;             ag-http2/connection.lisp (DATA-frame handling),
+;;;;             ag-http2/streams.lisp (unbounded stream-append-data)
+;;;;   MEDIUM-2  read-frame-rejects-frame-exceeding-max-frame-size
+;;;;             ag-http2/frames.lisp (read-frame allocates before size check)
+;;;;   LOW-3     percent-decode-tolerates-malformed-server-escapes
+;;;;             ag-grpc/metadata.lisp (percent-decode), reachable from a
+;;;;             malicious server's grpc-message trailer (ag-grpc/call.lisp)
+
+(in-package #:ag-grpc-tests)
+
+(in-suite security-tests)
+
+(defun call-with-octet-output-stream (fn)
+  "Call FN with a binary output stream backed by a temp file (contents
+   discarded). Mirrors CALL-WITH-OCTET-STREAM-FROM-BYTES for write paths so a
+   frame handler that emits WINDOW_UPDATE/etc. has a real sink to write to."
+  (let ((path (uiop:tmpize-pathname
+               (merge-pathnames "ag-grpc-sec-out-test"
+                                (uiop:temporary-directory)))))
+    (unwind-protect
+         (with-open-file (out path :direction :output
+                                   :element-type '(unsigned-byte 8)
+                                   :if-exists :supersede)
+           (funcall fn out))
+      (ignore-errors (delete-file path)))))
+
+;;;; ------------------------------------------------------------------------
+;;;; MEDIUM-1 — inbound flow control must apply backpressure
+;;;; ------------------------------------------------------------------------
+
+(test data-frame-buffering-is-bounded
+  "Because the receiver replenishes its flow-control window as DATA is accepted,
+   a peer that streams DATA without ever sending END_STREAM (or declares a huge
+   gRPC message length and trickles the body) would grow the per-stream buffer
+   (stream-append-data) without bound and exhaust server memory — there is no
+   max-receive-message-size (MEDIUM-1).
+
+   Secure behavior asserted: buffered-but-unconsumed request data per stream is
+   capped (*max-receive-buffer-size*); once it is exceeded the connection is
+   failed instead of buffering unboundedly. The cap is bound small here so the
+   test stays cheap."
+  (let ((conn (make-instance 'ag-http2::http2-connection :client-p nil))
+        (ag-http2::*max-receive-buffer-size* 2048))
+    (setf (ag-http2::connection-multiplexer conn)
+          (ag-http2::make-stream-multiplexer :client-p nil))
+    (call-with-octet-output-stream
+     (lambda (out)
+       (setf (ag-http2::connection-stream conn) out)
+       (flet ((feed (n)
+                (ag-http2::process-frame
+                 conn (ag-http2::make-data-frame
+                       1 (make-array n :element-type '(unsigned-byte 8)
+                                       :initial-element 65)))))
+         ;; Up to the cap is fine...
+         (finishes (feed 1024))
+         (finishes (feed 1024))
+         ;; ...exceeding it without END_STREAM must be rejected, not buffered.
+         (signals ag-http2::http2-connection-error (feed 1024)))))))
+
+;;;; ------------------------------------------------------------------------
+;;;; MEDIUM-2 — frames over SETTINGS_MAX_FRAME_SIZE must be rejected
+;;;; ------------------------------------------------------------------------
+
+(test read-frame-rejects-frame-exceeding-max-frame-size
+  "RFC 7540 §4.2: an endpoint MUST treat a frame whose length exceeds the
+   advertised SETTINGS_MAX_FRAME_SIZE (default 16384) as a connection error of
+   type FRAME_SIZE_ERROR, and the check must happen BEFORE the payload is
+   allocated. read-frame currently parses the 24-bit length and unconditionally
+   allocates a buffer of that size (up to ~16 MB) before reading, so a 9-byte
+   header forces a large allocation (MEDIUM-2).
+
+   This header declares length 16385 (one byte over the RFC default) and sends
+   no payload. Secure behavior asserted: read-frame signals an HTTP/2 error
+   carrying FRAME_SIZE_ERROR. (Today it allocates the buffer, fails the read,
+   and signals INTERNAL_ERROR via \"Incomplete frame payload\" instead.)"
+  (let ((header (make-array 9 :element-type '(unsigned-byte 8)
+                              :initial-contents
+                              '(#x00 #x40 #x01   ; length = 16385 (> 16384)
+                                #x00             ; type  = DATA
+                                #x00             ; flags
+                                #x00 #x00 #x00 #x01)))) ; stream id = 1
+    (call-with-octet-stream-from-bytes
+     header
+     (lambda (stream)
+       (handler-case
+           (progn
+             (ag-http2::read-frame stream)
+             (is-true nil
+                      "read-frame accepted a frame larger than MAX_FRAME_SIZE ~
+                       instead of signalling FRAME_SIZE_ERROR (MEDIUM-2)."))
+         (ag-http2::http2-error (e)
+           (is (= (ag-http2::http2-error-code e)
+                  ag-http2::+error-frame-size-error+)
+               "oversize frame must signal FRAME_SIZE_ERROR, got ~A (MEDIUM-2)."
+               (ag-http2::error-code-name (ag-http2::http2-error-code e)))))))))
+
+;;;; ------------------------------------------------------------------------
+;;;; LOW-3 — percent-decode must tolerate malformed peer-supplied escapes
+;;;; ------------------------------------------------------------------------
+
+(test percent-decode-tolerates-malformed-server-escapes
+  "The grpc-message trailer is attacker-influenced (sent by the peer/server)
+   and is percent-decoded on the receiving side (ag-grpc/call.lisp). A
+   truncated escape (\"%\" + one hex digit) drives parse-integer past the end
+   of the string, and a non-hex escape makes parse-integer signal — either way
+   an uncaught error crashes the in-flight RPC's response handling (LOW-3).
+
+   Secure behavior asserted: percent-decode never signals on malformed input;
+   it should pass such bytes through (or drop them) rather than error."
+  (finishes (ag-grpc::percent-decode "ok%2"))   ; truncated: only one hex digit
+  (finishes (ag-grpc::percent-decode "ok%ZZ"))  ; non-hex escape
+  (finishes (ag-grpc::percent-decode "trailing%"))) ; bare percent at end


### PR DESCRIPTION
…code

Three remote-input hardening fixes, each with a FiveAM regression reproducer in tests/security-tests.lisp (new security-tests suite):

* CL-SEC-2026-0208: cap per-stream buffered request data via ag-http2:*max-receive-buffer-size* (default 4 MiB) and fail the connection with ENHANCE_YOUR_CALM when exceeded. Previously a peer could stream DATA without END_STREAM and exhaust memory, since the flow-control window was replenished as data was accepted.

* CL-SEC-2026-0209: enforce SETTINGS_MAX_FRAME_SIZE in read-frame before allocating the payload (RFC 7540 4.2, FRAME_SIZE_ERROR), via new +default-max-frame-size+; connection-read-frame passes the locally-advertised value. Previously a 9-byte header could force a 16 MiB allocation.

* CL-SEC-2026-0210: percent-decode tolerates malformed peer-supplied grpc-message escapes (truncated/non-hex) instead of letting parse-integer raise and abort the client's call.

Full suite: 286/286 checks pass.